### PR TITLE
Fix webpack regex

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,7 @@ module.exports = {
 
     module: {
         loaders: [
-            { test: /\.js|\.jsx$/, exclude: /node_modules/, loader: 'babel', query: {
+            { test: /\.jsx?$/, exclude: /node_modules/, loader: 'babel', query: {
                     optional: ['runtime'],
                     stage: 0
                 }

--- a/webpackExamples.config.js
+++ b/webpackExamples.config.js
@@ -5,7 +5,7 @@ module.exports = {
     },
     module: {
         loaders: [
-            { test: /\.js|\.jsx$/, exclude: /node_modules/, loader: 'babel'},
+            { test: /\.jsx?$/, exclude: /node_modules/, loader: 'babel'},
             { test: /\.less$/, loader: 'style!css!less' }
         ]
     },


### PR DESCRIPTION
Thanks for creating this component. I have a few improvements I am going to send, but I don't mind if you choose to merge them or not.

First I noticed the regex in the webpack config is wrong, ony the second pattern is anchored to the end. I think you meant to do this?

````javascript
`/(\.js|\.jsx)$/`
````