### PR TITLE
add onScroll simulated event

### DIFF
--- a/examples/basic/js/app.jsx
+++ b/examples/basic/js/app.jsx
@@ -13,6 +13,10 @@ class App extends React.Component{
         this.setState({itemsCount: this.state.itemsCount + 10});
     }
 
+    handleScroll(scrollData){
+      console.log(scrollData);
+    }
+
     render() {
         var itemElements = [];
 
@@ -31,6 +35,7 @@ class App extends React.Component{
                   verticalContainerStyle={scrollBarStyles}
                   horizontalScrollbarStyle={scrollBarStyles}
                   horizontalContainerStyle={scrollBarStyles}
+                  onScroll={this.handleScroll}
                   >
 
                     {itemElements}

--- a/src/js/scrollArea.jsx
+++ b/src/js/scrollArea.jsx
@@ -145,6 +145,11 @@ export default class ScrollArea extends React.Component{
         if(this.canScrollX(newState)){
             newState.leftPosition = this.computeLeftPosition(deltaX, newState);
         }
+
+        if(this.props.onScroll){
+            this.props.onScroll(newState);
+        }
+        
         this.setState(newState);
     }
 
@@ -177,6 +182,10 @@ export default class ScrollArea extends React.Component{
 
         if(this.state.topPosition !== newState.topPosition || this.state.leftPosition !== newState.leftPosition){
             e.preventDefault();
+        }
+
+        if(this.props.onScroll){
+            this.props.onScroll(newState);
         }
 
         this.setState(newState);
@@ -306,6 +315,7 @@ ScrollArea.propTypes = {
     horizontal: React.PropTypes.bool,
     horizontalContainerStyle: React.PropTypes.object,
     horizontalScrollbarStyle: React.PropTypes.object,
+    onScroll: React.PropTypes.func,
 };
 
 ScrollArea.defaultProps = {


### PR DESCRIPTION
This should add an onScroll event to the component to notify the parent component when the container scrolls.  I bubbled up the current internal state of the scrollArea but if you have a better idea about what to expose let me know.