### PR TITLE
Fix for #42

### DIFF
--- a/src/js/Scrollbar.jsx
+++ b/src/js/Scrollbar.jsx
@@ -133,8 +133,10 @@ class ScrollBar extends React.Component {
     }
 
     handleMouseUp(e){
-        e.preventDefault();
-        this.setState({isDragging: false });
+        if (this.state.isDragging) {
+            e.preventDefault();
+            this.setState({isDragging: false });
+        }
     }
 
     createScrollStyles(){


### PR DESCRIPTION
This fixes issue #42. It just adds a simple check to only cancel the mouseup event in the case where a scrollbar was in the process of being dragged.

See explanation in issue. 