### PR TITLE
allow arrow keys in contenteditable elements

### DIFF
--- a/src/js/ScrollArea.jsx
+++ b/src/js/ScrollArea.jsx
@@ -274,7 +274,7 @@ export default class ScrollArea extends React.Component {
 
     handleKeyDown(e) {
         // only handle if scroll area is in focus
-        if (e.target.tagName.toLowerCase() !== 'input') {
+        if (e.target.tagName.toLowerCase() !== 'input' && !e.target.isContentEditable) {
             let deltaY = 0;
             let deltaX = 0;
             let lineHeight = this.lineHeightPx ? this.lineHeightPx : 10;


### PR DESCRIPTION
I do not mind if you merge it or not, it fixes my issue with arrow keys for quill.js.

This PR probably related to #77.
