### PR TITLE
Replace React.PropTypes / PropTypes 

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "run-sequence": "^1.1.4",
     "style-loader": "^0.13.0",
     "webpack": "^1.12.2",
-    "webpack-stream": "^3.1.0"
+    "webpack-stream": "^3.1.0",
+    "prop-types": "^15.5.6"
   },
   "bugs": {
     "url": "https://github.com/souhe/reactScrollbar/issues"

--- a/src/js/ScrollArea.jsx
+++ b/src/js/ScrollArea.jsx
@@ -3,6 +3,7 @@ import ScrollBar from './Scrollbar';
 import {findDOMNode, warnAboutFunctionChild, warnAboutElementChild, positiveOrZero, modifyObjValues} from './utils';
 import lineHeight from 'line-height';
 import {Motion, spring} from 'react-motion';
+import PropTypes from 'prop-types';
 
 const eventTypes = {
     wheel: 'wheel',
@@ -446,29 +447,29 @@ export default class ScrollArea extends React.Component {
 }
 
 ScrollArea.childContextTypes = {
-    scrollArea: React.PropTypes.object
+    scrollArea: PropTypes.object
 };
 
 ScrollArea.propTypes = {
-    className: React.PropTypes.string,
-    style: React.PropTypes.object,
-    speed: React.PropTypes.number,
-    contentClassName: React.PropTypes.string,
-    contentStyle: React.PropTypes.object,
-    vertical: React.PropTypes.bool,
-    verticalContainerStyle: React.PropTypes.object,
-    verticalScrollbarStyle: React.PropTypes.object,
-    horizontal: React.PropTypes.bool,
-    horizontalContainerStyle: React.PropTypes.object,
-    horizontalScrollbarStyle: React.PropTypes.object,
-    onScroll: React.PropTypes.func,
-    contentWindow: React.PropTypes.any,
-    ownerDocument: React.PropTypes.any,
-    smoothScrolling: React.PropTypes.bool,
-    minScrollSize: React.PropTypes.number,
-    swapWheelAxes: React.PropTypes.bool,
-    stopScrollPropagation: React.PropTypes.bool,
-    focusableTabIndex: React.PropTypes.number
+    className: PropTypes.string,
+    style: PropTypes.object,
+    speed: PropTypes.number,
+    contentClassName: PropTypes.string,
+    contentStyle: PropTypes.object,
+    vertical: PropTypes.bool,
+    verticalContainerStyle: PropTypes.object,
+    verticalScrollbarStyle: PropTypes.object,
+    horizontal: PropTypes.bool,
+    horizontalContainerStyle: PropTypes.object,
+    horizontalScrollbarStyle: PropTypes.object,
+    onScroll: PropTypes.func,
+    contentWindow: PropTypes.any,
+    ownerDocument: PropTypes.any,
+    smoothScrolling: PropTypes.bool,
+    minScrollSize: PropTypes.number,
+    swapWheelAxes: PropTypes.bool,
+    stopScrollPropagation: PropTypes.bool,
+    focusableTabIndex: PropTypes.number
 };
 
 ScrollArea.defaultProps = {

--- a/src/js/Scrollbar.jsx
+++ b/src/js/Scrollbar.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import {Motion, spring} from 'react-motion';
 import {modifyObjValues} from './utils';
+import PropTypes from 'prop-types';
+
 
 class ScrollBar extends React.Component {
     constructor(props){
@@ -161,18 +163,18 @@ class ScrollBar extends React.Component {
 }
 
 ScrollBar.propTypes = {
-    onMove: React.PropTypes.func,
-    onPositionChange: React.PropTypes.func,
-    onFocus: React.PropTypes.func,
-    realSize: React.PropTypes.number,
-    containerSize: React.PropTypes.number,
-    position: React.PropTypes.number,
-    containerStyle: React.PropTypes.object,
-    scrollbarStyle: React.PropTypes.object,
-    type: React.PropTypes.oneOf(['vertical', 'horizontal']),
-    ownerDocument: React.PropTypes.any,
-    smoothScrolling: React.PropTypes.bool,
-    minScrollSize: React.PropTypes.number
+    onMove: PropTypes.func,
+    onPositionChange: PropTypes.func,
+    onFocus: PropTypes.func,
+    realSize: PropTypes.number,
+    containerSize: PropTypes.number,
+    position: PropTypes.number,
+    containerStyle: PropTypes.object,
+    scrollbarStyle: PropTypes.object,
+    type: PropTypes.oneOf(['vertical', 'horizontal']),
+    ownerDocument: PropTypes.any,
+    smoothScrolling: PropTypes.bool,
+    minScrollSize: PropTypes.number
 };
 
 ScrollBar.defaultProps = {


### PR DESCRIPTION
I updated the react to version 15.5.0 and saw an error in the console:

> Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.


We need to update components to use prop-types package. More info in official blog: https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html


```js
// Before (15.4 and below)
import React from 'react';

class Component extends React.Component {
  render() {
    return <div>{this.props.text}</div>;
  }
}

Component.propTypes = {
  text: React.PropTypes.string.isRequired,
}

// After (15.5)
import React from 'react';
import PropTypes from 'prop-types';

class Component extends React.Component {
  render() {
    return <div>{this.props.text}</div>;
  }
}

Component.propTypes = {
  text: PropTypes.string.isRequired,
};
```