### PR TITLE
Ignore touch events if nothing to scroll

### DIFF
--- a/src/js/ScrollArea.jsx
+++ b/src/js/ScrollArea.jsx
@@ -187,8 +187,10 @@ export default class ScrollArea extends React.Component {
     }
 
     handleTouchMove(e) {
-        e.preventDefault();
-        e.stopPropagation();
+        if (this.canScroll()) {
+            e.preventDefault();
+            e.stopPropagation();
+        }
 
         let {touches} = e;
         if (touches.length === 1) {
@@ -422,6 +424,10 @@ export default class ScrollArea extends React.Component {
     canScrollX(state = this.state) {
         let scrollableX = state.realWidth > state.containerWidth;
         return scrollableX && this.props.horizontal;
+    }
+
+    canScroll(state = this.state) {
+        return this.canScrollY(state) || this.canScrollX(state);
     }
 
     getModifiedPositionsIfNeeded(newState) {


### PR DESCRIPTION
It is important in responsive design cases, if scroll required in desktop version and native scroll should be used in mobile.