### PR TITLE
Fix handleTouchEnd called not after a handleTouchStart

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "ScrollArea component for react",
   "main": "./dist/scrollArea.js",
   "scripts": {
-    "test": "./node_modules/.bin/karma start karma.config.js --single-run --browsers PhantomJS"
+    "test": "./node_modules/.bin/karma start karma.config.js --single-run --browsers PhantomJS",
+    "build": "gulp build"
   },
   "repository": {
     "type": "git",

--- a/src/js/ScrollArea.jsx
+++ b/src/js/ScrollArea.jsx
@@ -217,9 +217,17 @@ export default class ScrollArea extends React.Component {
     }
 
     handleTouchEnd(e) {
-        let {deltaX, deltaY, timestamp} = this.eventPreviousValues;
+        let deltaX,
+          deltaY,
+          timestamp;
+        if (this.eventPreviousValues) {
+            deltaX = this.eventPreviousValues.deltaX;
+            deltaY = this.eventPreviousValues.deltaY;
+            timestamp = this.eventPreviousValues.timestamp;
+        }
         if (typeof deltaX === 'undefined') deltaX = 0;
         if (typeof deltaY === 'undefined') deltaY = 0;
+        if (typeof timestamp === 'undefined') timestamp = Date.now();
         if (Date.now() - timestamp < 200) {
             this.setStateFromEvent(this.composeNewState(-deltaX * 10, -deltaY * 10), eventTypes.touchEnd);
         }


### PR DESCRIPTION
In my application, when I click the first time inside the scrollbar with a Chrome under mobile emulation, the event `handleTouchEnd` is called but no `handleTouchStart`.  
This PR protects the `handleTouchEnd` event handler to throw that exception, since `this.eventPreviousValues` is undefined:
```
Uncaught TypeError: Cannot read property 'deltaX' of undefined
    at t.value (/bundle.js?5a5c0ac8dc6a61225da1:2:1002364)
    at Object.j (/bundle.js?5a5c0ac8dc6a61225da1:2:762488)
    at Object.invokeGuardedCallback (/bundle.js?5a5c0ac8dc6a61225da1:2:761767)
    at Object.invokeGuardedCallbackAndCatchFirstError (/bundle.js?5a5c0ac8dc6a61225da1:2:761882)
    at Z (/bundle.js?5a5c0ac8dc6a61225da1:2:763535)
    at ee (bundle.js?5a5c0ac8dc6a61225da1:2:763990)
    at ne (/bundle.js?5a5c0ac8dc6a61225da1:2:764175)
    at Array.forEach (native)
    at J (/bundle.js?5a5c0ac8dc6a61225da1:2:763804)
    at le (/bundle.js?5a5c0ac8dc6a61225da1:2:764909)
```