### PR TITLE
Reduce the z-index value

### DIFF
--- a/src/less/scrollArea.less
+++ b/src/less/scrollArea.less
@@ -46,7 +46,7 @@
         position: absolute;
         background: none;
         opacity: .1;
-        z-index: 9999;
+        z-index: 99;
 
         -webkit-transition: all .4s;
            -moz-transition: all .4s;


### PR DESCRIPTION
I think using 9999 for z-index is a bad choice, 99 is enough.
This will help when using with other UI libraries, such as the bootstrap.