### PR TITLE
check if the content and the wrapper exists before computing the sizes

### DIFF
--- a/src/js/ScrollArea.jsx
+++ b/src/js/ScrollArea.jsx
@@ -370,10 +370,10 @@ export default class ScrollArea extends React.Component {
     }
 
     computeSizes() {
-        let realHeight = this.content.offsetHeight;
-        let containerHeight = this.wrapper.offsetHeight;
-        let realWidth = this.content.offsetWidth;
-        let containerWidth = this.wrapper.offsetWidth;
+        let realHeight = (this.content) ? this.content.offsetHeight : 0;
+        let containerHeight = (this.wrapper) ? this.wrapper.offsetHeight : 0;
+        let realWidth = (this.content) ? this.content.offsetWidth : 0;
+        let containerWidth = (this.content) ? this.wrapper.offsetWidth : 0;
 
         return {
             realHeight: realHeight,


### PR DESCRIPTION
I had some problems  with the functions `scrollToBottom` and `refresh` calling them from `componentDIdMount()/componentDidUpdate()` that showed that the container field of the object was null.
![35433320_1968985546486676_9056465179620933632_n](https://user-images.githubusercontent.com/25799714/41566063-65442cce-7362-11e8-90b2-df115d9f3107.png)

I believe that one should verify if the fields are defined and if not to initialise the requested variables with zero (width and height).
