### PR TITLE
Added missed arguments for removeEventListener

### DIFF
--- a/src/js/ScrollArea.jsx
+++ b/src/js/ScrollArea.jsx
@@ -82,7 +82,7 @@ export default class ScrollArea extends React.Component {
         if (this.props.contentWindow) {
             this.props.contentWindow.removeEventListener("resize", this.bindedHandleWindowResize);
         }
-        this.wrapper.removeEventListener("wheel");
+        this.wrapper.removeEventListener("wheel", this.handleWheel.bind(this), {passive: false});
     }
 
     componentDidUpdate() {


### PR DESCRIPTION
removeEventListener requires a seconds argument, otherwise we get an exception in the componentWillUnmount method. Also referring to this article https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener in the last paragraph we can see "It's worth noting that some browser releases have been inconsistent on this, and unless you have specific reasons otherwise, it's probably wise to use the same values used for the call to addEventListener() when calling removeEventListener()."